### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://mywebapp4free.visualstudio.com/1cb792cf-33e9-47c0-a693-0ae978f744a5/cde98898-584c-43e1-9861-be5780442973/_apis/work/boardbadge/227d551e-9631-4373-a964-a4fd8514b9c8)](https://mywebapp4free.visualstudio.com/1cb792cf-33e9-47c0-a693-0ae978f744a5/_boards/board/t/cde98898-584c-43e1-9861-be5780442973/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#22](https://mywebapp4free.visualstudio.com/1cb792cf-33e9-47c0-a693-0ae978f744a5/_workitems/edit/22). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.